### PR TITLE
Show a better error message when invoice amount is missing

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1780,6 +1780,10 @@ App.updateInvoiceDetails = ({swap}) => {
         text = 'Using this currency to pay this invoice is not yet supported.';
         break;
 
+      case 'ExpectedTokensForFeeCalculation':
+        text = 'This invoice does not include an amount. Try one with amount?';
+        break;
+
       case 'ChainFeesTooHighToSwap':
         text = 'Value too low for a chain swap. Use a higher value invoice?';
         break;


### PR DESCRIPTION
After pasting an invoice that didn't have an amount I received a generic "Unexpected error" message. This change adds a case handler for that server error in the client code.

Let me know if that's the right moment to handle this error or if there is a better place.