### PR TITLE
Fix removed gRPC in ln-service

### DIFF
--- a/service/get_invoice_details.js
+++ b/service/get_invoice_details.js
@@ -3,7 +3,7 @@ const {nextTick} = process;
 const asyncAuto = require('async/auto');
 const asyncTimeout = require('async/timeout');
 const {getPendingChannels} = require('ln-service');
-const {getRoutes} = require('ln-service');
+const {getRouteToDestination} = require('ln-service');
 const {probeForRoute} = require('ln-service');
 const {returnResult} = require('asyncjs-util');
 const {subscribeToProbe} = require('ln-service');
@@ -146,9 +146,9 @@ module.exports = ({cache, check, invoice, network}, cbk) => {
     {
       const net = parsedInvoice.network.toUpperCase();
 
-      return getRoutes({
+      return getRouteToDestination({
         lnd,
-        cltv_delta: parsedInvoice.cltv_delta,
+        cltv_delta: parsedInvoice.timeout,
         destination: parsedInvoice.destination,
         is_adjusted_for_past_failures: true,
         max_fee: getSwapFee.converted_fee,
@@ -163,8 +163,8 @@ module.exports = ({cache, check, invoice, network}, cbk) => {
         const configuredMaxHops = process.env[`SSS_LN_${net}_MAX_HOPS`];
 
         const maxHops = parseInt(configuredMaxHops || defaultMaxHops, decBase);
-
-        const routes = res.routes.filter(({hops}) => hops.length <= maxHops);
+        
+        const routes = res.route.hops.length <= maxHops ? res.route.hops : null;
 
         return cbk(null, {routes});
       });

--- a/service/get_invoice_details.js
+++ b/service/get_invoice_details.js
@@ -148,7 +148,7 @@ module.exports = ({cache, check, invoice, network}, cbk) => {
 
       return getRouteToDestination({
         lnd,
-        cltv_delta: parsedInvoice.timeout,
+        cltv_delta: parsedInvoice.cltv_delta,
         destination: parsedInvoice.destination,
         is_adjusted_for_past_failures: true,
         max_fee: getSwapFee.converted_fee,
@@ -163,7 +163,7 @@ module.exports = ({cache, check, invoice, network}, cbk) => {
         const configuredMaxHops = process.env[`SSS_LN_${net}_MAX_HOPS`];
 
         const maxHops = parseInt(configuredMaxHops || defaultMaxHops, decBase);
-        
+
         const routes = res.route.hops.length <= maxHops ? res.route.hops : null;
 
         return cbk(null, {routes});

--- a/service/get_invoice_details.js
+++ b/service/get_invoice_details.js
@@ -164,7 +164,7 @@ module.exports = ({cache, check, invoice, network}, cbk) => {
 
         const maxHops = parseInt(configuredMaxHops || defaultMaxHops, decBase);
 
-        const routes = res.route.hops.length <= maxHops ? res.route.hops : null;
+        const routes = res.route.hops.length <= maxHops ? res.route.hops : [];
 
         return cbk(null, {routes});
       });


### PR DESCRIPTION
Replaced `getRoutes` with `getRouteToDestination` because `getRoutes` has been removed after [ln-service@50.0.1](https://github.com/alexbosworth/ln-service/blob/6a809ada7a0ac76bb89e894ab00e9917d3569207/CHANGELOG.md#breaking-changes-2)